### PR TITLE
impr: docker files are the docker way

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,11 +9,11 @@ services:
             - "5432"
         environment:
             POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
+            POSTGRES_PASSWORD: ${PW_POSTGRES}
     oms-discounts:
         build:
-            context: ./$PATH_OMS_DISCOUNTS/oms-discounts
-            dockerfile: ./Dockerfile.dev
+            context: ./$PATH_OMS_DISCOUNTS/..
+            dockerfile: ./docker/oms-discounts/Dockerfile.dev
         image: aegee/oms-discounts:dev
         volumes:
             - oms-discounts-media:/usr/app/media
@@ -31,13 +31,9 @@ services:
         labels:
             - "traefik.backend=oms-discounts"
             - "traefik.port=8084"
-            - "traefik.frontend.rule=HostRegexp:{domain:[a-z0-9.]+};PathPrefix:/services/oms-discounts/api;PathPrefixStrip:/services/oms-discounts/api"
+            - "traefik.frontend.rule=PathPrefix:/services/oms-discounts/api;PathPrefixStrip:/services/oms-discounts/api"
             - "traefik.frontend.priority=110"
             - "traefik.enable=true"
-            - "registry.categories=(discounts, 10);(events, 10);(notifications, 10)"
-            - "registry.servicename=oms-discounts"
-
-
 
 volumes:
     postgres:

--- a/docker/oms-discounts/Dockerfile
+++ b/docker/oms-discounts/Dockerfile
@@ -16,10 +16,8 @@ USER node
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"
 
-RUN npm install -g --loglevel warn nodemon \
-     && npm cache clean --force \
-     && npm install --loglevel warn
+RUN npm install --loglevel warn
 
-CMD sh /usr/app/scripts/bootstrap.sh && nodemon -e "js,json" lib/run.js
+CMD sh /usr/app/scripts/bootstrap.sh && npm start
 
 EXPOSE 8084

--- a/docker/oms-discounts/bootstrap.sh
+++ b/docker/oms-discounts/bootstrap.sh
@@ -5,8 +5,6 @@ then
   cp config/index.js.example config/index.js
 fi
 
-echo "Installing packages..."
-npm install --loglevel warn
 echo "Creating database..."
 npm run db:create
 echo "Migrating database..."

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Discounts module for OMS, for populating codes and for distributing them to AEGEE members.",
   "main": "lib/run.js",
   "scripts": {
+    "start": "node lib/run.js",
     "lint": "eslint .",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 && git add CHANGELOG.md",
     "db:create": "sequelize db:create",


### PR DESCRIPTION
I made some modifications:

1) Add `npm start` script
2) Dockerfile is production-ready and does not use nodemon but the above `npm start`
3) both Dockerfile and Dockerfile.dev copy the files necessary for the working and run `npm install` there. `bootstrap.sh` only makes the config file and db stuff (which we can't have at build time, at least the db stuff)

Please test in local then merge, after that you can merge oms-docker PR