### PR TITLE
Add proper dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
-      - run: (cd docker/oms-discounts/ && docker build  --tag aegee/oms-discounts:$(node -p "require('../../package.json').version") --tag aegee/oms-discounts:latest -f Dockerfile.dev .)
+      - run: docker build  --tag aegee/oms-discounts:$(node -p "require('./package.json').version") --tag aegee/oms-discounts:latest -f ./docker/oms-discounts/Dockerfile.dev .
       - run: docker login --username $DOCKER_LOGIN --password $DOCKER_PASSWORD
       - run: docker push aegee/oms-discounts:$(node -p "require('./package.json').version")
       - run: docker push aegee/oms-discounts:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# [0.7.0](https://github.com/AEGEE/oms-discounts/compare/0.6.0...0.7.0) (2019-09-13)
+
+
+### Bug Fixes
+
+* **deps:** added jest-junit for tests ([8bf3d27](https://github.com/AEGEE/oms-discounts/commit/8bf3d27))
+* **docker:** fixed Dockerfile ([55f07a3](https://github.com/AEGEE/oms-discounts/commit/55f07a3))
+* **general:** removed Travis ([cf41ac6](https://github.com/AEGEE/oms-discounts/commit/cf41ac6))
+
+
+### Features
+
+* **docker:** added proper dockerfile. Fixes MEMB-613 ([b429928](https://github.com/AEGEE/oms-discounts/commit/b429928))
+
+
+
 # [0.6.0](https://github.com/AEGEE/oms-discounts/compare/0.5.2...0.6.0) (2019-09-01)
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     oms-discounts:
         build:
             context: ./$PATH_OMS_DISCOUNTS/..
-            dockerfile: .docker/oms-discounts/Dockerfile.dev
+            dockerfile: ./docker/oms-discounts/Dockerfile.dev
         image: aegee/oms-discounts:dev
         volumes:
             - oms-discounts-media:/usr/app/media

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,8 +12,8 @@ services:
             POSTGRES_PASSWORD: ${PW_POSTGRES}
     oms-discounts:
         build:
-            context: ./$PATH_OMS_DISCOUNTS/oms-discounts
-            dockerfile: ./Dockerfile.dev
+            context: ./$PATH_OMS_DISCOUNTS/..
+            dockerfile: .docker/oms-discounts/Dockerfile.dev
         image: aegee/oms-discounts:dev
         volumes:
             - oms-discounts-media:/usr/app/media
@@ -29,11 +29,9 @@ services:
         labels:
             - "traefik.backend=oms-discounts"
             - "traefik.port=8084"
-            - "traefik.frontend.rule=HostRegexp:{domain:[a-z0-9.]+};PathPrefix:/services/oms-discounts/api;PathPrefixStrip:/services/oms-discounts/api"
+            - "traefik.frontend.rule=PathPrefix:/services/oms-discounts/api;PathPrefixStrip:/services/oms-discounts/api"
             - "traefik.frontend.priority=110"
             - "traefik.enable=true"
-            - "registry.categories=(discounts, 10);(events, 10);(notifications, 10)"
-            - "registry.servicename=oms-discounts"
 volumes:
     postgres-oms-discounts:
         driver: "local"

--- a/docker/oms-discounts/Dockerfile.dev
+++ b/docker/oms-discounts/Dockerfile.dev
@@ -4,7 +4,8 @@ RUN mkdir -p /usr/app/src \
 	&& mkdir -p /usr/app/media \
 	&& mkdir -p /usr/app/scripts
 
-ADD ./bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY ./docker/oms-discounts/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY ./ /usr/app/src
 
 RUN chown -R node:node /usr/app
 
@@ -16,7 +17,8 @@ ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"
 
 RUN npm install -g --loglevel warn nodemon && npm cache clean --force
+RUN npm install --loglevel warn
 
-CMD sh /usr/app/scripts/bootstrap.sh && nodemon -e "js,json" lib/run.js
+CMD sh /usr/app/scripts/bootstrap.sh && npm start
 
 EXPOSE 8084

--- a/docker/oms-discounts/bootstrap.sh
+++ b/docker/oms-discounts/bootstrap.sh
@@ -5,8 +5,6 @@ then
   cp config/index.js.example config/index.js
 fi
 
-echo "Installing packages..."
-npm install --loglevel warn
 echo "Creating database..."
 npm run db:create
 echo "Migrating database..."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oms-discounts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oms-discounts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Discounts module for OMS, for populating codes and for distributing them to AEGEE members.",
   "main": "lib/run.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Discounts module for OMS, for populating codes and for distributing them to AEGEE members.",
   "main": "lib/run.js",
   "scripts": {
+    "start": "nodemon -e 'js,json' lib/run.js",
     "lint": "eslint .",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 && git add CHANGELOG.md",
     "db:create": "sequelize db:create",


### PR DESCRIPTION
Fixes MEMB-613 for discounts, superseded #2.
@linuxbandit fyi

The only thing that's different from #2 is that I've left nodemon as it is, as I need it for local development, as well as in other services. We should think how to separate dev and prod before doing this, then we can use node directly in prod and nodemon in dev (not for autorestarting the container, but for restarting the app on files change).